### PR TITLE
update jmeter

### DIFF
--- a/jmeter/Dockerfile
+++ b/jmeter/Dockerfile
@@ -1,6 +1,6 @@
 FROM java:8-jdk
 
-ARG JMETER_VERSION="3.3"
+ARG JMETER_VERSION="5.1"
 ENV JMETER_HOME /opt/apache-jmeter-${JMETER_VERSION}
 ENV	JMETER_BIN	${JMETER_HOME}/bin
 ENV	JMETER_DOWNLOAD_URL  https://archive.apache.org/dist/jmeter/binaries/apache-jmeter-${JMETER_VERSION}.tgz


### PR DESCRIPTION
With jmeter version 3.3 I got the following error:

```
Error in NonGUIDriver java.lang.IllegalArgumentException: Problem loading XML from:'/var/jenkins_home/workspace/BackendJob/SymlexFlow.jmx', missing class com.thoughtworks.xstream.converters.ConversionException: 
---- Debugging information ----
cause-exception     : com.thoughtworks.xstream.converters.ConversionException
cause-message       : 
first-jmeter-class  : org.apache.jmeter.save.converters.HashTreeConverter.unmarshal(HashTreeConverter.java:67)
class               : org.apache.jmeter.save.ScriptWrapper
required-type       : org.apache.jorphan.collections.ListedHashTree
converter-type      : org.apache.jmeter.save.ScriptWrapperConverter
path                : /jmeterTestPlan/hashTree/hashTree/hashTree[4]/hashTree[4]/hashTree[2]/hashTree/JSONPathAssertion
line number         : 1015
version             : 3.3 r1808647
-------------------------------
```
Updating to version 5.1 solved it.
